### PR TITLE
Quickstarts: Search: Remove the `language` parameter

### DIFF
--- a/quickstarts/TwelveLabs_Quickstart_Search.ipynb
+++ b/quickstarts/TwelveLabs_Quickstart_Search.ipynb
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -178,7 +178,7 @@
     "  raise Exception(\"Video file was not provided\")\n",
     "for video_file in video_files:\n",
     "  print(f\"Uploading {video_file}\")\n",
-    "  task = client.task.create(index_id=index.id, file=video_file, language=\"en\")\n",
+    "  task = client.task.create(index_id=index.id, file=video_file)\n",
     "  print(f\"Created task: id={task.id}\")\n",
     "\n",
     "  # (Optional) Monitor the video indexing process\n",


### PR DESCRIPTION
Quickstarts: Search: Remove the `language` parameter