### PR TITLE
Fix: Mermaid diagram syntax in VideoDB README

### DIFF
--- a/integrations/VideoDB/README.md
+++ b/integrations/VideoDB/README.md
@@ -35,7 +35,7 @@ Reference: Notion — “Unlock Real-Time Video Understanding with VideoDB and T
 ```mermaid
 flowchart LR
   Cam[IP Camera / RTSP] --> VDB[VideoDB RTStream]
-  VDB --> IDX[Scene Indexing (Pegasus 1.2)]
+  VDB --> IDX[Scene Indexing<br>&lpar;Pegasus 1.2&rpar;]
   IDX --> EVT[Event Definition]
   EVT --> ALT[Alert Engine]
   ALT --> WH[Webhook Callback]


### PR DESCRIPTION
Corrected a Mermaid diagram parsing error in the VideoDB README. 
The parentheses in "(Pegasus 1.2)" were causing a rendering issue. 
This commit replaces them with HTML character codes to ensure proper display and adds a line break for better readability.

**Issue**
<img width="1326" height="728" alt="image" src="https://github.com/user-attachments/assets/38790699-faf5-4e9e-8419-30ad75c10e3f" />

**Fix**
<img width="1449" height="541" alt="image" src="https://github.com/user-attachments/assets/1d1128e6-5b20-4490-99cf-94700af5534a" />

