### PR TITLE
Add Segment videos quickstart notebook and modernize Analyze notebook

### DIFF
--- a/quickstarts/TwelveLabs_Quickstart_Analyze.ipynb
+++ b/quickstarts/TwelveLabs_Quickstart_Analyze.ipynb
@@ -3,12 +3,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "LcFAkSKdxM-T"
+    "id": "an-md-1"
    },
    "source": [
     "<table align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/1.0.0-beta/TwelveLabs_Quickstart_Analyze.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/TwelveLabs_Quickstart_Analyze.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -16,42 +16,42 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "VmpYRcFNT30r"
+    "id": "an-md-2"
    },
    "source": [
     "# Analyze videos\n",
     "\n",
-    "This guide shows how to utilize the TwelveLabs Python SDK to analyze videos and generate text based on their content.\n",
+    "This guide shows how to use the TwelveLabs Python SDK to analyze videos and generate text based on their content.\n",
     "\n",
     "## Key concepts\n",
     "\n",
-    "- **Index**: A container that organizes your video content\n",
-    "- **Asset**: Your uploaded file\n",
-    "- **Indexed asset**: A video that has been indexed and is ready for downstream tasks\n",
+    "- **Asset**: Your uploaded content\n",
+    "- **Prompt**: The instruction that tells the platform what text to generate\n",
     "\n",
     "## How it works\n",
     "\n",
-    "To analyze your videos, you must first upload and index them. The platform indexes videos asynchronously. After indexing completes, you can analyze your videos to generate text based on their content.\n",
+    "To analyze a video, upload it as an asset, then pass the asset to the analyze method with a prompt. The platform generates text based on the content of your video. This guide uses the synchronous method, which returns results without polling and supports streaming. It handles videos up to 1 hour. For longer videos up to 2 hours, use the asynchronous method in the [Analyze videos](https://docs.twelvelabs.io/docs/guides/analyze-videos) guide.\n",
     "\n",
-    "The upload method in this guide allows for files up to 4 GB when using publicly accessible URLs and 200 MB for local files. For details about the available upload methods and the corresponding limits, see the [Upload methods](https://docs.twelvelabs.io/docs/concepts/upload-methods) page.\n",
+    "The upload method in this guide accepts public video URLs up to 2 GB and local files up to 200 MB. For details about the available upload methods and the corresponding limits, see the [Upload methods](https://docs.twelvelabs.io/docs/concepts/upload-methods) page.\n",
     "\n",
     "**Customize text generation**\n",
     "\n",
     "You can customize text generation in the following ways:\n",
     "- Adjust the temperature to control the randomness of the output\n",
-    "- Set the maximum token limit in the response\n",
-    "Request structured JSON responses for programmatic processing\n",
+    "- Set the maximum number of tokens in the response\n",
+    "- Request structured JSON responses for programmatic processing\n",
     "- Choose a response method based on your use case:\n",
-    "  - Streaming responses deliver text fragments in real-time as they are generated, enabling immediate processing and feedback. This method is the default behavior of the platform and is ideal for applications requiring incremental updates.\n",
-    "  - Non-streaming responses deliver the complete generated text in a single response, simplifying processing when the full result is needed."
+    "  - Streaming responses deliver text fragments in real time as they are generated. This is the default behavior and suits applications that need incremental updates.\n",
+    "  - Non-streaming responses deliver the complete generated text in a single response, which simplifies processing when you need the full result."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-3"
+   },
    "source": [
     "# Prerequisites\n",
-    "\n",
     "\n",
     "- To use the platform, you need an API key:\n",
     "  1. If you don't have an account, [sign up](https://playground.twelvelabs.io/) for a free account. No credit card is required to use the Free plan. This plan allows you to index up to 600 minutes of videos, which is sufficient for a small project.\n",
@@ -63,19 +63,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-4"
+   },
    "source": [
     "# Procedure"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-5"
+   },
    "source": [
     "## Install the TwelveLabs Python SDK"
    ]
@@ -91,24 +90,29 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-6"
+   },
    "source": [
     "## Import the required packages"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
-    "from twelvelabs import TwelveLabs"
+    "from twelvelabs import TwelveLabs\n",
+    "from twelvelabs.types import VideoContext_AssetId, AnalyzePromptV2"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-7"
+   },
    "source": [
     "## Configure your API key\n"
    ]
@@ -130,33 +134,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create an index\n",
-    "\n",
-    "Indexes store and organize your video data, allowing you to group related videos. This guide shows how to create one, but you can also use an existing index. See the [Indexes](https://docs.twelvelabs.io/docs/concepts/indexes) page for more details on creating an index and specifying the model configuration."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client = TwelveLabs(api_key=TL_API_KEY)\n",
-    "\n",
-    "index = client.indexes.create(\n",
-    "    index_name=\"cb-pegasus-1\",\n",
-    "    models=[{\"model_name\": \"pegasus1.2\", \"model_options\": [\"visual\", \"audio\"]}]\n",
-    ")\n",
-    "if not index.id:\n",
-    "    raise RuntimeError(\"Failed to create an index.\")\n",
-    "print(f\"Created index: id={index.id}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-8"
+   },
    "source": [
     "## Upload a video"
    ]
@@ -167,6 +147,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "client = TwelveLabs(api_key=TL_API_KEY)\n",
+    "\n",
     "asset = client.assets.create(\n",
     "    method=\"url\",\n",
     "    url=\"<YOUR_VIDEO_URL>\" # Example: https://github.com/twelvelabs-io/twelvelabs-developer-experience/raw/refs/heads/main/quickstarts/steve_jobs_introduces_iphone_in_2007.mp4\n",
@@ -177,7 +159,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-9"
+   },
    "source": [
     "## Check the status of the asset"
    ]
@@ -201,57 +185,8 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Index your video"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "indexed_asset = client.indexes.indexed_assets.create(\n",
-    "    index_id=index.id,\n",
-    "    asset_id=asset.id,\n",
-    "    # enable_video_stream=True\n",
-    ")\n",
-    "print(f\"Created indexed asset: id={indexed_asset.id}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Monitor the indexing process"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Waiting for indexing to complete.\")\n",
-    "while True:\n",
-    "    indexed_asset = client.indexes.indexed_assets.retrieve(\n",
-    "        index_id=index.id,\n",
-    "        indexed_asset_id=indexed_asset.id\n",
-    "    )\n",
-    "    print(f\"  Status={indexed_asset.status}\")\n",
-    "    if indexed_asset.status == \"ready\":\n",
-    "        print(\"Indexing complete!\")\n",
-    "        break\n",
-    "    elif indexed_asset.status == \"failed\":\n",
-    "        raise RuntimeError(\"Indexing failed\")\n",
-    "    time.sleep(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
-    "id": "qNhC07lCYGHg"
+    "id": "an-md-10"
    },
    "source": [
     "## Analyze videos to generate text"
@@ -259,26 +194,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-11"
+   },
    "source": [
-    "### Streaming responses"
+    "### Streaming responses\n",
+    "\n",
+    "Stream the generated text as it becomes available. This is the default response method."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "SeGb7DSpYHjT",
-    "outputId": "1a63585d-a4c4-4116-f2f4-ca83527f7181"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "text_stream = client.analyze_stream(\n",
-    "    video_id=indexed_asset.id,\n",
-    "    prompt=\"<YOUR_PROMPT>\", # Example: \"Summarize this video\"\n",
+    "    model_name=\"pegasus1.5\",\n",
+    "    video=VideoContext_AssetId(asset_id=asset.id),\n",
+    "    prompt_v_2=AnalyzePromptV2(input_text=\"<YOUR_PROMPT>\"), # Example: \"Summarize this video\"\n",
     "    # temperature=0.2,\n",
     "    # max_tokens=1024,\n",
     ")\n",
@@ -290,9 +224,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-12"
+   },
    "source": [
-    "### Non-streaming responses"
+    "### Non-streaming responses\n",
+    "\n",
+    "Receive the complete generated text in a single response."
    ]
   },
   {
@@ -302,8 +240,9 @@
    "outputs": [],
    "source": [
     "text = client.analyze(\n",
-    "    video_id=indexed_asset.id,\n",
-    "    prompt=\"<YOUR_PROMPT>\",\n",
+    "    model_name=\"pegasus1.5\",\n",
+    "    video=VideoContext_AssetId(asset_id=asset.id),\n",
+    "    prompt_v_2=AnalyzePromptV2(input_text=\"<YOUR_PROMPT>\"),\n",
     "    # temperature=0.2,\n",
     "    # max_tokens=1024,\n",
     ")\n",
@@ -313,9 +252,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-13"
+   },
    "source": [
-    "### Structured responses (streaming)"
+    "### Structured responses (streaming)\n",
+    "\n",
+    "Stream a structured JSON response that matches a schema you define in the `response_format` parameter."
    ]
   },
   {
@@ -324,13 +267,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from twelvelabs.types import ResponseFormat, StreamAnalyzeResponse_StreamEnd\n",
+    "from twelvelabs.types import SyncResponseFormat, StreamAnalyzeResponse_StreamEnd\n",
     "\n",
     "text_stream = client.analyze_stream(\n",
-    "    video_id=indexed_asset.id,\n",
-    "    prompt=\"<YOUR_PROMPT>\",\n",
+    "    model_name=\"pegasus1.5\",\n",
+    "    video=VideoContext_AssetId(asset_id=asset.id),\n",
+    "    prompt_v_2=AnalyzePromptV2(input_text=\"<YOUR_PROMPT>\"),\n",
     "    # max_tokens=2048,\n",
-    "    response_format=ResponseFormat(\n",
+    "    response_format=SyncResponseFormat(\n",
     "        type=\"json_schema\",\n",
     "        json_schema={\n",
     "            \"type\": \"object\",\n",
@@ -353,9 +297,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-14"
+   },
    "source": [
-    "### Structured responses (non-streaming)"
+    "### Structured responses (non-streaming)\n",
+    "\n",
+    "Receive a complete structured JSON response that matches a schema you define in the `response_format` parameter."
    ]
   },
   {
@@ -365,13 +313,15 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "from twelvelabs.types import ResponseFormat\n",
+    "from twelvelabs.types import SyncResponseFormat\n",
     "\n",
     "text = client.analyze(\n",
-    "    video_id=indexed_asset.id,\n",
-    "    prompt=\"<YOUR_PROMPT>\",\n",
+    "    model_name=\"pegasus1.5\",\n",
+    "    video=VideoContext_AssetId(asset_id=asset.id),\n",
+    "    prompt_v_2=AnalyzePromptV2(input_text=\"<YOUR_PROMPT>\"),\n",
     "    # max_tokens=2048,\n",
-    "    response_format=ResponseFormat(\n",
+    "    response_format=SyncResponseFormat(\n",
+    "        type=\"json_schema\",\n",
     "        json_schema={\n",
     "            \"type\": \"object\",\n",
     "            \"properties\": {\n",
@@ -383,16 +333,18 @@
     "    ),\n",
     ")\n",
     "print(json.dumps(text.model_dump(), indent=2))\n",
-    "print (f\"Finish reason: {text.finish_reason}\")\n"
+    "print(f\"Finish reason: {text.finish_reason}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "an-md-15"
+   },
    "source": [
     "# Next steps\n",
     "\n",
-    "For a comprehensive guide, see the [Analyze videos](https://docs.twelvelabs.io/docs/guides/analyze-videos) page.\n"
+    "For a comprehensive guide, see the [Analyze videos](https://docs.twelvelabs.io/docs/guides/analyze-videos) page."
    ]
   }
  ],

--- a/quickstarts/TwelveLabs_Quickstart_Embeddings.ipynb
+++ b/quickstarts/TwelveLabs_Quickstart_Embeddings.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<table align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/1.0.0-beta/TwelveLabs_Quickstart_Embeddings.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/TwelveLabs_Quickstart_Embeddings.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
     "  </td>\n",
     "</table>"
    ]

--- a/quickstarts/TwelveLabs_Quickstart_Search.ipynb
+++ b/quickstarts/TwelveLabs_Quickstart_Search.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<table align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/1.0.0-beta/TwelveLabs_Quickstart_Search.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/TwelveLabs_Quickstart_Search.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
     "  </td>\n",
     "</table>"
    ]

--- a/quickstarts/TwelveLabs_Quickstart_Segment.ipynb
+++ b/quickstarts/TwelveLabs_Quickstart_Segment.ipynb
@@ -1,0 +1,330 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-1"
+   },
+   "source": [
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/twelvelabs-io/twelvelabs-developer-experience/blob/main/quickstarts/TwelveLabs_Quickstart_Segment.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in  Colab</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-2"
+   },
+   "source": [
+    "# Segment videos\n",
+    "\n",
+    "This guide shows how to use the TwelveLabs Python SDK to segment videos into structured, timestamped data.\n",
+    "\n",
+    "## Key concepts\n",
+    "\n",
+    "- **Asset**: Your uploaded content\n",
+    "- **Analysis task**: An asynchronous operation for processing your video. Contains a status and the results when complete.\n",
+    "- **Segment definition**: A description of a type of segment you want to extract. Each definition includes a unique identifier, a natural language description, and optional custom fields.\n",
+    "- **Segment field**: A custom metadata field to extract for each segment. Each field has a name, a type, and a description.\n",
+    "\n",
+    "## How it works\n",
+    "\n",
+    "To segment a video, upload it as an asset, then create an asynchronous analysis task with Pegasus 1.5. Set the analysis mode to time-based metadata and provide one or more segment definitions. The platform identifies the segment boundaries and returns custom metadata for each segment as a JSON-encoded string.\n",
+    "\n",
+    "The upload method in this guide supports public video URLs up to 2 GB and local files up to 200 MB. For details about the available upload methods and the corresponding limits, see the [Upload methods](https://docs.twelvelabs.io/docs/concepts/upload-methods) page.\n",
+    "\n",
+    "**Customize segmentation**\n",
+    "\n",
+    "You can customize segmentation in the following ways:\n",
+    "- Submit up to 10 segment definitions in a single request to extract different types of segments\n",
+    "- Define up to 20 custom fields per segment definition, each typed as string, boolean, number, integer, or array\n",
+    "- List the allowed values for a field with `enum` to constrain the output\n",
+    "- Set minimum and maximum segment durations to control the segment boundaries\n",
+    "- Add up to 4 reference images to a segment definition to provide visual context for detection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-3"
+   },
+   "source": [
+    "# Prerequisites\n",
+    "\n",
+    "- To use the platform, you need an API key:\n",
+    "  1. If you don't have an account, [sign up](https://playground.twelvelabs.io/) for a free account. No credit card is required to use the Free plan. This plan allows you to index up to 600 minutes of videos, which is sufficient for a small project.\n",
+    "  2. Go to the [API Keys](https://playground.twelvelabs.io/dashboard/api-keys) page.\n",
+    "  3. If you need to create a new key, select the **Create API Key** button. Enter a name and set the expiration period. The default is 12 months.\n",
+    "  4. Select the **Copy** icon next to your key to copy it to your clipboard.\n",
+    "- Your video files must meet the [format requirements](https://docs.twelvelabs.io/docs/concepts/models/pegasus#input-requirements)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-4"
+   },
+   "source": [
+    "# Procedure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-5"
+   },
+   "source": [
+    "## Install the TwelveLabs Python SDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install twelvelabs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-6"
+   },
+   "source": [
+    "## Import the required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "from twelvelabs import TwelveLabs\n",
+    "from twelvelabs.types import AsyncResponseFormat, VideoContext_AssetId"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-7"
+   },
+   "source": [
+    "## Configure your API key\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For Google Colab, store your API key as a Secret named `TL_API_KEY`. If you don't know how to create a Colab Secret, see https://medium.com/@parthdasawant/how-to-use-secrets-in-google-colab-450c38e3ec75.\n",
+    "\n",
+    "from google.colab import userdata\n",
+    "TL_API_KEY = userdata.get(\"TL_API_KEY\")\n",
+    "\n",
+    "# For other Python environments, you can use environment variables\n",
+    "# TL_API_KEY = os.environ.get('TL_API_KEY')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-8"
+   },
+   "source": [
+    "## Upload a video"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = TwelveLabs(api_key=TL_API_KEY)\n",
+    "\n",
+    "asset = client.assets.create(\n",
+    "    method=\"url\",\n",
+    "    url=\"<YOUR_VIDEO_URL>\" # Example: https://github.com/twelvelabs-io/twelvelabs-developer-experience/raw/refs/heads/main/quickstarts/steve_jobs_introduces_iphone_in_2007.mp4\n",
+    "    # Or use method=\"direct\" and file=open(\"<PATH_TO_VIDEO_FILE>\", \"rb\") to upload a file from the local file system\n",
+    ")\n",
+    "print(f\"Created asset: id={asset.id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-9"
+   },
+   "source": [
+    "## Check the status of the asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Waiting for asset to be ready...\")\n",
+    "while True:\n",
+    "    asset = client.assets.retrieve(asset.id)\n",
+    "    if asset.status == \"ready\":\n",
+    "        print(\"Asset is ready\")\n",
+    "        break\n",
+    "    if asset.status == \"failed\":\n",
+    "        raise RuntimeError(f\"Asset processing failed: id={asset.id}\")\n",
+    "    time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-10"
+   },
+   "source": [
+    "## Create a video segmentation task\n",
+    "\n",
+    "Define the segments and fields you want to extract, then create an asynchronous task. This example segments the video into scenes and extracts three fields for each scene. This operation is asynchronous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "video = VideoContext_AssetId(asset_id=asset.id)\n",
+    "task = client.analyze_async.tasks.create(\n",
+    "    video=video,\n",
+    "    model_name=\"pegasus1.5\",\n",
+    "    analysis_mode=\"time_based_metadata\",\n",
+    "    response_format=AsyncResponseFormat(\n",
+    "        type=\"segment_definitions\",\n",
+    "        segment_definitions=[\n",
+    "            {\n",
+    "                \"id\": \"scenes\",\n",
+    "                \"description\": \"Segment the video into distinct scenes based on changes in setting, topic, or visual composition\",\n",
+    "                \"fields\": [\n",
+    "                    {\n",
+    "                        \"name\": \"sentiment\",\n",
+    "                        \"type\": \"string\",\n",
+    "                        \"description\": \"The overall sentiment of this scene\",\n",
+    "                        \"enum\": [\"positive\", \"negative\", \"neutral\"]\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"name\": \"key_objects\",\n",
+    "                        \"type\": \"array\",\n",
+    "                        \"description\": \"Notable objects visible in the scene\",\n",
+    "                        \"items\": {\"type\": \"string\"}\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"name\": \"contains_speech\",\n",
+    "                        \"type\": \"boolean\",\n",
+    "                        \"description\": \"Whether the scene contains speech or dialogue\"\n",
+    "                    }\n",
+    "                ]\n",
+    "            }\n",
+    "        ]\n",
+    "    )\n",
+    ")\n",
+    "print(f\"Task ID: {task.task_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-11"
+   },
+   "source": [
+    "## Monitor the status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "while True:\n",
+    "    task = client.analyze_async.tasks.retrieve(task.task_id)\n",
+    "    if task.status == \"ready\":\n",
+    "        print(\"Task completed\")\n",
+    "        break\n",
+    "    elif task.status == \"failed\":\n",
+    "        print(\"Task failed\")\n",
+    "        break\n",
+    "    else:\n",
+    "        print(\"Task still processing...\")\n",
+    "        time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-12"
+   },
+   "source": [
+    "## Process the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = json.loads(task.result.data)\n",
+    "for segment in data[\"scenes\"]:\n",
+    "    print(f\"\\n[{segment['start_time']:.1f}s - {segment['end_time']:.1f}s]\")\n",
+    "    meta = segment[\"metadata\"]\n",
+    "    print(f\"  Sentiment: {meta['sentiment']}\")\n",
+    "    print(f\"  Key objects: {', '.join(meta['key_objects'])}\")\n",
+    "    print(f\"  Contains speech: {meta['contains_speech']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seg-md-13"
+   },
+   "source": [
+    "# Next steps\n",
+    "\n",
+    "For a comprehensive guide, see the [Segment videos](https://docs.twelvelabs.io/docs/guides/segment-videos) page."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary

Adds a **Segment videos** quickstart notebook and brings the existing quickstart notebooks in line with the v1.3 fern quickstarts.

Three independent changes, one commit each:

1. **`feat`: add `TwelveLabs_Quickstart_Segment.ipynb`** — new quickstart mirroring the [Segment videos quickstart](https://docs.twelvelabs.io/docs/get-started/quickstart/segment-videos): upload a video as an asset → create an asynchronous analyze task with `analysis_mode=time_based_metadata` on Pegasus 1.5 → poll for completion → parse the timestamped segment metadata.
2. **`fix`: modernize `TwelveLabs_Quickstart_Analyze.ipynb`** — the notebook was still on the legacy index + `pegasus1.2` + `video_id` flow while its quickstart had moved to the asset-based flow. It now uses `analyze_stream` / `analyze` with `VideoContext_AssetId`, `prompt_v_2` (`AnalyzePromptV2`), `SyncResponseFormat`, and `pegasus1.5`; the index-creation, indexing, and indexing-monitor steps are removed. Also corrects the upload limit (2 GB URL / 200 MB local for Pegasus) and fixes a missing list bullet. All four response variants (streaming, non-streaming, structured streaming, structured non-streaming) are retained.
3. **`fix`: correct Colab badge paths** — the "Run in Colab" badges pointed to `quickstarts/1.0.0-beta/…`, which does not exist. They now point to `quickstarts/<file>.ipynb`, matching the actual file locations and the documentation site links. Touches Search, Embeddings, Analyze, and Segment.

## Test plan

All code was verified by extracting the literal code cells from each notebook into `.py` files and running them against the live API (`twelvelabs==1.2.8`). The only substitutions were the unavoidable headless ones: the `%pip` magic line, the Colab `userdata` key cell → `os.environ`, and the `<YOUR_VIDEO_URL>` / `<YOUR_PROMPT>` placeholders.

- [x] **Segment** — asset created → task completed → parsed 12 timestamped segments with `sentiment` / `key_objects` / `contains_speech`.
- [x] **Analyze** — all four variants returned valid output; both structured calls returned `finish_reason: stop`.
- [x] `nbformat` validation passes for both regenerated notebooks; all code cells pass `ast` syntax checks.
- [ ] Reviewer: open each notebook's Colab badge to confirm the link resolves once merged to `main`.

## Notes

- The Analyze rewrite is the only behavioral change; the Segment notebook is additive and the badge fix is cosmetic.
- Follow-up (separate, in the docs repo): add a Colab row for the Segment notebook to the "Interactive notebooks" table once this merges to `main`.
